### PR TITLE
removed required config parameter breaks Release v0.14.12 - 2017/01/3…

### DIFF
--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -7,7 +7,7 @@ module Fluent::Plugin
     helpers :timer, :event_emitter
 
     desc "The key for part of multiline log"
-    config_param :key, :string, required: true
+    config_param :key, :string
     desc "The separator of lines"
     config_param :separator, :string, default: "\n"
     desc "The number of lines"


### PR DESCRIPTION
…0. [error]: #0 unexpected error error_class=ArgumentError error=unknown option required for configuration parameter: key.

Sorry messed the last pull request. 