### PR TITLE
Small rewording of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ You can handle timeout events and remaining buffers on shutdown this plugin.
 </label>
 ```
 
-Handle timeout error same as normal logs.
+Handle timeout log lines the same as normal logs.
 
 ```aconf
 <filter **>


### PR DESCRIPTION
I was under the impression this was referring to the 'fluent.info' error not the actual log line.
After reading https://github.com/fluent-plugins-nursery/fluent-plugin-concat/issues/8 this was clarified for me. Hopefully this small rewording clarifies this.
Thanks