### PR TITLE
Exit early and don't eat logs if the target key doesn't exist

### DIFF
--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -84,6 +84,10 @@ module Fluent::Plugin
           new_es.add(time, record)
           next
         end
+        if record[@key].nil?
+          new_es.add(time, record)
+          next
+        end
         begin
           flushed_es = process(tag, time, record)
           unless flushed_es.empty?

--- a/test/plugin/test_filter_concat.rb
+++ b/test/plugin/test_filter_concat.rb
@@ -132,6 +132,25 @@ class FilterConcatTest < Test::Unit::TestCase
       filtered = filter(CONFIG, messages)
       assert_equal(expected, filtered)
     end
+    
+    def test_missing_keys
+      messages = [
+        { "host" => "example.com", "message" => "message 1" },
+        { "host" => "example.com", "message" => "message 2" },
+        { "host" => "example.com", "message" => "message 3" },
+        { "host" => "example.com", "message" => "message 4" },
+        { "host" => "example.com", "message" => "message 5" },
+        { "host" => "example.com", "message" => "message 6" },
+        { "host" => "example.com", "somekey" => "message 7" },
+      ]
+      expected = [
+        { "host" => "example.com", "message" => "message 1\nmessage 2\nmessage 3" },
+        { "host" => "example.com", "message" => "message 4\nmessage 5\nmessage 6" },
+        { "host" => "example.com", "somekey" => "message 7" },
+      ]
+      filtered = filter(CONFIG, messages)
+      assert_equal(expected, filtered)
+    end
 
     def test_stream_identity
       messages = [


### PR DESCRIPTION
As mentioned in https://github.com/fluent-plugins-nursery/fluent-plugin-concat/issues/42