### PR TITLE
Fix Docker logs example

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Handle single line JSON from Docker containers.
 <filter **>
   @type concat
   key message
-  multiline_end_regexp /\\n$/
+  multiline_end_regexp "/\\n$/"
 </filter>
 ```
 


### PR DESCRIPTION
Looks like `multiline_end_regexp /\\n$/` doesn't work because it escapes both `\` chars so the result pattern looks like `/\\\\n$/` in fluent's startup log output

However, if it is quoted like `multiline_end_regexp "/\\n$/"` or just one backslash `multiline_end_regexp /\n$/`, then it works