### PR TITLE
on_timer: Do not pass an exception up the calling chain

### DIFF
--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -109,6 +109,8 @@ module Fluent::Plugin
       return if @flush_interval <= 0
       return if @finished
       flush_timeout_buffer
+    rescue => e
+      log.error "failed to flush timeout buffer", error: e
     end
 
     def process(tag, time, record)


### PR DESCRIPTION
### Problem

The timer helper of Fluentd core immediately detaches itself from the
event loop if its callback raise an unhandled exception (so no processing
occurs after an exception).

Since ConcatFilter.on_timer() does not catch any exception at all,
there's a quite good chance that the flushing thread stops working
in the middle of operation with the following error:

> [error]: #0 Timer detached. title=:filter_concat_timer

### Related report

For an actual user report of this issue, see https://github.com/fluent/fluentd/issues/1946.

### Fix

This patch introduces an rescue clause on `on_timer` to prevent exceptions from
bubbling up the chain.