### PR TITLE
separate keys for log concat and regexp matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Or install it yourself as:
 
 The key for part of multiline log.
 
+**regexp_key**
+
+The key on which to do regex searches. Defaults to `key`.
+
 **separator**
 
 The separator of lines.
@@ -134,6 +138,27 @@ Handle single line JSON from Docker containers.
   @type concat
   key message
   multiline_end_regexp /\n$/
+</filter>
+```
+
+Handle single split logs from Kubernetes Containerd containers.
+
+```aconf
+<source>
+  @type tail
+  /var/log/containers/*.log
+  <parse>
+    format regexp
+    time_format %Y-%m-%dT%H:%M:%S.%N%:z
+    expression /^(?<time>.+)\b(?<stream>stdout|stderr)\b(?<criprefix>P|F)\b(?<message>.*)$/
+  </parse>
+</source>
+
+<filter **>
+  @type concat
+  key message
+  search_key criprefix
+  multiline_end_regexp /^F/
 </filter>
 ```
 


### PR DESCRIPTION
Support separate keys for regexp matching and log concatenation.

For containerd/cri in Kubernetes, logs are written as plaintext and long lines are split on a configurable size.  Partial lines are prefixed with a `P` and the final line of a multi-line or single line log are prefixed with `F`:
```
2018-06-28T18:04:27.18380794Z stdout P long log 1
2018-06-28T18:04:27.183861445Z stdout P long log 2
...
2018-06-28T18:04:27.183892587Z stdout F long log N
``` 
In order to avoid including the split line flag in the concatenated message, I propose to support regexp matching against a different record key than the key you want to concatenate.