### PR TITLE
Docker partial_message example: do not add new line between parts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Handle single line JSON from Docker containers.
 </filter>
 ```
 
-Handle Docker's `partial_message`.
+Handle Docker's `partial_message`, and do not add new line between parts.
 
 ```aconf
 <filter>
@@ -164,6 +164,7 @@ Handle Docker's `partial_message`.
   key message
   partial_key partial_message
   partial_value true
+  separator ""
 </filter>
 ```
 


### PR DESCRIPTION
Solves https://github.com/fluent-plugins-nursery/fluent-plugin-concat/issues/56