### PR TITLE
Added to README for supporting Docker v19.03

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,20 @@ Handle Docker logs splitted in several parts (using `partial_message`), and do n
 ```aconf
 <filter>
   @type concat
-  key message
+  key log
   partial_key partial_message
   partial_value true
+  separator ""
+</filter>
+```
+
+(Docker v19.03+) Handle Docker logs splitted in several parts (using `use_partial_metadata`), and do not add new line between parts.
+
+```aconf
+<filter>
+  @type concat
+  key log
+  use_partial_metadata true
   separator ""
 </filter>
 ```


### PR DESCRIPTION
Hey folks :smiley: 

In a previous commit (https://github.com/fluent-plugins-nursery/fluent-plugin-concat/commit/776972fac67878d596ea4ef27bb4455006265deb) we added support for Docker v19.03
but we forgot to add an example in the README. This PR basically does that.

Also fixes the previous example for handling Docker logs. I've updated the
key from `message` to `log` as Docker's fluentd driver wraps the
container's log line in the `log` key as seen in this commit
https://github.com/moby/moby/commit/361a582ba0bccea04a8ea1799e68779fa66abb9f#diff-4e76640044eca60a4a45cd8631049282R112

Cheers