### PR TITLE
Handle CRI-O log on partial_cri mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ Handle containerd/cri in Kubernetes.
   path /var/log/containers/*.log
   <parse>
     @type regexp
-    expression /^(?<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z) (?<output>\w+) (?<partial_flag>[FP]) (?<message>.+)$/
+    expression /^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$/
+    time_format %Y-%m-%dT%H:%M:%S.%L%z
   </parse>
   tag k8s
   @label @CONCAT
@@ -206,8 +207,9 @@ Handle containerd/cri in Kubernetes.
   <filter k8s>
     @type concat
     key message
-    partial_key partial_flag
-    partial_value P
+    use_partial_cri_logtag true
+    partial_cri_logtag_key logtag
+    partial_cri_stream_key stream
   </filter>
   <match k8s>
     @type relabel

--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -58,11 +58,18 @@ module Fluent::Plugin
       end
     end
 
+    def required_params
+      params = [@n_lines.nil?, @multiline_start_regexp.nil?, @multiline_end_regexp.nil?, @partial_key.nil?, !@use_partial_metadata, !@use_partial_cri_logtag]
+      names = ["n_lines", "multiline_start_regexp", "multiline_end_regexp", "partial_key", "use_partial_metadata", "use_partial_cri_logtag"]
+      return params, names
+    end
+
     def configure(conf)
       super
 
-      if @n_lines.nil? && @multiline_start_regexp.nil? && @multiline_end_regexp.nil? && @partial_key.nil? && !@use_partial_metadata && !@use_partial_cri_logtag
-        raise Fluent::ConfigError, "Either n_lines, multiline_start_regexp, multiline_end_regexp, partial_key, use_partial_metadata or use_partial_cri_logtag is required"
+      params, names = required_params
+      if params.reject{|e| e == true}.empty?
+        raise Fluent::ConfigError, "Either #{[names[0..-2].join(", "), names[-1]].join(" or ")} is required"
       end
       if @n_lines && (@multiline_start_regexp || @multiline_end_regexp)
         raise Fluent::ConfigError, "n_lines and multiline_start_regexp/multiline_end_regexp are exclusive"

--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -68,7 +68,7 @@ module Fluent::Plugin
       super
 
       params, names = required_params
-      if params.reject{|e| e == true}.empty?
+      if params.all?
         raise Fluent::ConfigError, "Either #{[names[0..-2].join(", "), names[-1]].join(" or ")} is required"
       end
       if @n_lines && (@multiline_start_regexp || @multiline_end_regexp)


### PR DESCRIPTION
**motivation:**
We can also handle with regexp mode for CRI-O log format,
but I think that it is reasonable to add CRI-O handling mode on this
plugin.

In the newer kubernetes, it start to use CRI-O format for logging.
We should handle this format on concat plugin with specific mode.

ref: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-cri-logging.md

On kubelet implementation for parsing, stream type is just for checking
stream names validity and then they are thrown away.
Users want to obtain concatenated log contents not for attached metadata.

ref: https://github.com/kubernetes/kubernetes/blob/629d5ab21349021cf7d38236620785071ee541b4/pkg/kubelet/kuberuntime/logs/logs.go#L124-L168

When we use regexp to concat CRI-O log, it is hard to remove attached
metadata records such as stream names(stdout|stderr) and partial_flag(P
or F).