### PR TITLE
Fix timeout logs

### DIFF
--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -50,11 +50,10 @@ module Fluent::Plugin
 
     def initialize
       super
-
       @buffer = Hash.new {|h, k| h[k] = [] }
       @timeout_map_mutex = Thread::Mutex.new
       @timeout_map_mutex.synchronize do
-        @timeout_map = Hash.new {|h, k| h[k] = Fluent::Engine.now }
+        @timeout_map = Hash.new {|h, k| h[k] = time_event_now }
       end
     end
 
@@ -241,7 +240,7 @@ module Fluent::Plugin
         end
       end
       @timeout_map_mutex.synchronize do
-        @timeout_map[stream_identity] = Fluent::Engine.now
+        @timeout_map[stream_identity] = time_event_now
       end
       case @mode
       when :line
@@ -389,7 +388,7 @@ module Fluent::Plugin
     end
 
     def flush_timeout_buffer
-      now = Fluent::Engine.now
+      now =time_event_now
       timeout_stream_identities = []
       @timeout_map_mutex.synchronize do
         @timeout_map.each do |stream_identity, previous_timestamp|
@@ -432,5 +431,11 @@ module Fluent::Plugin
         router.emit_error_event(tag, time, record, TimeoutError.new(message))
       end
     end
+
+    def time_event_now
+      now = Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)
+      Fluent::EventTime.new(now / 1_000_000_000, now % 1_000_000_000)
+    end
+
   end
 end

--- a/lib/fluent/plugin/filter_concat.rb
+++ b/lib/fluent/plugin/filter_concat.rb
@@ -388,7 +388,7 @@ module Fluent::Plugin
     end
 
     def flush_timeout_buffer
-      now =time_event_now
+      now = time_event_now
       timeout_stream_identities = []
       @timeout_map_mutex.synchronize do
         @timeout_map.each do |stream_identity, previous_timestamp|


### PR DESCRIPTION
If a timeout occured the logs were not emitted properly by the plugin because Fluent::Engine.now allways delivered the same timestamp. Because of that flush_timeout_buffer never did anything. I replaced it with the same call Fluent::Engine.now does in the background and now it works. I also added a test case for that.