### PR TITLE
ci: test with more newer ruby

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -9,18 +9,21 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.5
-          - 2.6
           - 2.7
-          - 3.0
+          - '3.0'
+          - 3.1
+          - 3.2
+          - 3.3
+          - 3.4
         os:
           - ubuntu-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        rubygems: latest
     - name: unit testing
       env:
         CI: true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,15 +8,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2', '3.3', '3.4' ]
         os:
           - windows-latest
     name: Ruby ${{ matrix.ruby }} unit testing on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        rubygems: latest
     - name: unit testing
       env:
         CI: true


### PR DESCRIPTION
* use latest checkout action
* drop obsolete ruby version
* use latest rubygems for 2.7
* fix incorrect version, it should quote '3.0' because 3.0 was treated as 3.