### PR TITLE
ci: add dependabot.yml to update GitHub actions regularly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'


### PR DESCRIPTION
Even though Dependabot was enabled by default, it
does not update it to up-to-date.

Control "Dependabot version update" explicitly.